### PR TITLE
fix #18: nested props are ignored if the first one is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = (UserProps) => {
 
         // warn if props won't resolve from plugin
         if (!value) {
-          return
+          continue
         }
 
         // create and append prop to :root

--- a/index.test.js
+++ b/index.test.js
@@ -111,6 +111,22 @@ a {
   )
 })
 
+it('Can jit a single, undefined prop that has fallbacks and nested props', async () => {
+  await run(
+`a {
+  color: var(--orange, var(--pink), hotpink);
+}`, 
+`:root {
+  --pink: #ffc0cb;
+}
+a {
+  color: var(--orange, var(--pink), hotpink);
+}`, 
+  MockProps
+  )
+})
+
+
 it('Can jit a single prop with spaces that has fallbacks and nested props', async () => {
   await run(
 `a {


### PR DESCRIPTION
I did a little research on #18 and it turns out that the bug is only present if the first prop is undefined. This pr fixes the issue and adds a test-case.

closes #18 