### PR TITLE
Configure adaptive prop

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -54,13 +54,13 @@ it('Can jit a single prop', async () => {
   await run(
 `a {
   color: var(--red);
-}`,
+}`, 
 `:root {
   --red: #f00;
 }
 a {
   color: var(--red);
-}`,
+}`, 
   MockProps
   )
 })
@@ -84,13 +84,13 @@ it('Can jit a single prop that has fallbacks', async () => {
   await run(
 `a {
   color: var(--red, hotpink);
-}`,
+}`, 
 `:root {
   --red: #f00;
 }
 a {
   color: var(--red, hotpink);
-}`,
+}`, 
   MockProps
   )
 })
@@ -114,14 +114,14 @@ it('Can jit a single prop that has fallbacks and nested props', async () => {
   await run(
 `a {
   color: var(--red, var(--pink), hotpink);
-}`,
+}`, 
 `:root {
   --red: #f00;
   --pink: #ffc0cb;
 }
 a {
   color: var(--red, var(--pink), hotpink);
-}`,
+}`, 
   MockProps
   )
 })
@@ -130,13 +130,13 @@ it('Can jit a single, undefined prop that has fallbacks and nested props', async
   await run(
 `a {
   color: var(--orange, var(--pink), hotpink);
-}`,
+}`, 
 `:root {
   --pink: #ffc0cb;
 }
 a {
   color: var(--orange, var(--pink), hotpink);
-}`,
+}`, 
   MockProps
   )
 })
@@ -164,7 +164,7 @@ it('Can jit multiple props', async () => {
   color: var(--red);
   border-color: var(--pink);
   padding-block-start: var( --size-1 );
-}`,
+}`, 
 `:root {
   --red: #f00;
   --pink: #ffc0cb;
@@ -174,7 +174,7 @@ a {
   color: var(--red);
   border-color: var(--pink);
   padding-block-start: var( --size-1 );
-}`,
+}`, 
   MockProps
   )
 })
@@ -183,14 +183,14 @@ it('Can jit multiple props from shorthand', async () => {
   await run(
 `a {
   padding-block: var(--size-1) var( --size-2  );
-}`,
+}`, 
 `:root {
   --size-1: 1rem;
   --size-2: 2rem;
 }
 a {
   padding-block: var(--size-1) var( --size-2  );
-}`,
+}`, 
   MockProps
   )
 })
@@ -199,7 +199,7 @@ it('Can jit props from inside functions', async () => {
   await run(
 `a {
   color: hsl(var(--h) var(--s) var( --l ));
-}`,
+}`, 
 `:root {
   --h: 200;
   --s: 50%;
@@ -207,7 +207,7 @@ it('Can jit props from inside functions', async () => {
 }
 a {
   color: hsl(var(--h) var(--s) var( --l ));
-}`,
+}`, 
   MockProps
   )
 })
@@ -217,14 +217,14 @@ it('Only adds a prop one time to :root', async () => {
 `a {
   color: var(--red);
   border-color: var(--red );
-}`,
+}`, 
 `:root {
   --red: #f00;
 }
 a {
   color: var(--red);
   border-color: var(--red );
-}`,
+}`, 
   MockProps
   )
 })
@@ -255,12 +255,12 @@ it('Can jit a keyframe animation', async () => {
   await run(
 `a {
   animation: var(--fade-in);
-}`,
+}`, 
 `:root {
   --fade-in: fade-in .5s ease;
 }a {
   animation: var(--fade-in);
-}@keyframes fade-in {to { opacity: 1 }}`,
+}@keyframes fade-in {to { opacity: 1 }}`, 
   MockProps
   )
 })
@@ -271,14 +271,14 @@ it('Can jit @custom-media', async () => {
   a {
     color: white;
   }
-}`,
+}`, 
 `@custom-media --dark (prefers-color-scheme: dark);
 :root{}
 @media (--dark) {
   a {
     color: white;
   }
-}`,
+}`, 
   MockProps
   )
 })
@@ -327,7 +327,7 @@ it('Can jit props from a CSS file', async () => {
     border-color: var( --pink );
     animation: var(--fade-in);
   }
-}`,
+}`, 
 `@custom-media --dark (prefers-color-scheme: dark);
 :root{
   --red: #f00;
@@ -341,7 +341,7 @@ it('Can jit props from a CSS file', async () => {
     animation: var(--fade-in);
   }
 }
-@keyframes fade-in {to { opacity: 1 }}`,
+@keyframes fade-in {to { opacity: 1 }}`, 
   { files: ['./props.test.css']}
   )
 })
@@ -354,7 +354,7 @@ it('Can jit props from a CSS file via glob', async () => {
     border-color: var( --pink );
     animation: var(--fade-in);
   }
-}`,
+}`, 
 `@custom-media --dark (prefers-color-scheme: dark);
 :root{
   --red: #f00;
@@ -368,7 +368,7 @@ it('Can jit props from a CSS file via glob', async () => {
     animation: var(--fade-in);
   }
 }
-@keyframes fade-in {to { opacity: 1 }}`,
+@keyframes fade-in {to { opacity: 1 }}`, 
   { files: ['./*.test.css']}
   )
 })
@@ -384,13 +384,13 @@ it('Can jit props to a custom selector', async () => {
   await run(
 `a {
   color: var(--red);
-}`,
+}`, 
 `:global {
   --red: #f00;
 }
 a {
   color: var(--red);
-}`,
+}`, 
   {
     ... MockProps,
     custom_selector: ':global',
@@ -402,10 +402,10 @@ it('Wont create a :root {} context unless props are found', async () => {
   await run(
 `a {
   color: red;
-}`,
+}`, 
 `a {
   color: red;
-}`,
+}`, 
   {
     ... MockProps
   }
@@ -416,7 +416,7 @@ it('Can jit a light and dark adaptive prop', async () => {
   await run(
 `p {
   color: var(--text);
-}`,
+}`, 
 `:root {
   --text: white;
 }
@@ -427,7 +427,7 @@ p {
   :root {
     --text: black;
   }
-}`,
+}`, 
   MockProps
   )
 })
@@ -449,7 +449,7 @@ p {
   }
 }`,
   {
-  ... MockPropsWithCustomAdaptiveProp,
+  ...MockPropsWithCustomAdaptiveProp,
   adaptive_prop_selector: '-dark'
   }
   )

--- a/index.test.js
+++ b/index.test.js
@@ -30,16 +30,6 @@ const MockProps = {
 }
 
 const MockPropsWithCustomAdaptiveProp = {
-  '--red': '#f00',
-  '--pink': '#ffc0cb',
-  '--h': 200,
-  '--s': '50%',
-  '--l': '50%',
-  '--size-1': '1rem',
-  '--size-2': '2rem',
-  '--fade-in': 'fade-in .5s ease',
-  '--fade-in-@': '@keyframes fade-in {to { opacity: 1 }}',
-  '--dark': '@custom-media --dark (prefers-color-scheme: dark);',
   '--text': 'white',
   '--text-dark': 'black',
 }
@@ -432,7 +422,7 @@ p {
   )
 })
 
-it('Can jit a light and dark with custom adaptive prop', async () => {
+it('Can jit a light and dark color with a custom adaptive prop parameter', async () => {
   await run(
 `p {
   color: var(--text);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-jit-props",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "PostCSS plugin to insert variables from a data source based on discovered usage",
   "keywords": [
     "postcss",


### PR DESCRIPTION
Hi!. 

Current implementation of adaptive prop (-@media:dark) contains characters that throws an not-valid syntax error on postcss compile step when props are parsed from css files not JSON. 
This PR adds a functionality to configure it.

Thank you.