### PR TITLE
implement file dependency messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,24 +28,23 @@ const getAdaptivePropSelector = (userProps) => {
 }
 
 module.exports = (UserProps) => {
-  const STATE = {
-    mapped: null,            // track prepended props
-    mapped_dark: null,       // track dark mode prepended props
-
-    target_layer: null,       // layer for props
-    target_rule: null,       // :root for props
-    target_rule_dark: null,  // :root for dark props
-    target_ss: null,         // stylesheet for keyframes/MQs
-    target_media_dark: null, // dark media query props
-  }
-
-  const adaptivePropSelector = getAdaptivePropSelector(UserProps)
-
   return {
     postcssPlugin: 'postcss-jit-props',
-
     prepare() {
       const UserPropsCopy = JSON.parse(JSON.stringify(UserProps));
+
+      const STATE = {
+        mapped: null,            // track prepended props
+        mapped_dark: null,       // track dark mode prepended props
+
+        target_layer: null,       // layer for props
+        target_rule: null,       // :root for props
+        target_rule_dark: null,  // :root for dark props
+        target_ss: null,         // stylesheet for keyframes/MQs
+        target_media_dark: null, // dark media query props
+      }
+
+      const adaptivePropSelector = getAdaptivePropSelector(UserProps)
 
       return {
         async Once(node, { result, Rule, AtRule }) {

--- a/index.test.js
+++ b/index.test.js
@@ -41,6 +41,10 @@ async function run (input, output, options = { }) {
   let result = await postcss([plugin(options)]).process(input, { from: undefined })
   expect(result.css).toEqual(output)
   expect(result.warnings()).toHaveLength(0)
+
+  if (options.files?.length) {
+    expect(result.messages.filter(x => x.type === 'dependency')).toHaveLength(options.files?.length)
+  }
 }
 
 it('Can jit a single prop', async () => {

--- a/index.test.js
+++ b/index.test.js
@@ -466,3 +466,34 @@ p {
   }
   )
 })
+
+it('Supports parallel runners', async () => {
+  const pluginInstance = plugin({
+    '--red': '#f00',
+    '--pink': '#ffc0cb',
+  });
+
+  let [resultA, resultB, resultC, resultD] = await Promise.all([
+    postcss([pluginInstance]).process(`a { color: var(--red); }`, { from: undefined }),
+    postcss([pluginInstance]).process(`a { color: var(--pink); }`, { from: undefined }),
+    postcss([pluginInstance]).process(`a { color: var(--red); }`, { from: undefined }),
+    postcss([pluginInstance]).process(`a { color: var(--pink); }`, { from: undefined }),
+  ])
+
+  let resultE = await postcss([pluginInstance]).process(`a { color: green; }`, { from: undefined })
+
+  expect(resultA.css).toEqual(':root { --red: #f00; }\na { color: var(--red); }')
+  expect(resultA.warnings()).toHaveLength(0)
+
+  expect(resultB.css).toEqual(':root { --pink: #ffc0cb; }\na { color: var(--pink); }')
+  expect(resultB.warnings()).toHaveLength(0)
+
+  expect(resultC.css).toEqual(':root { --red: #f00; }\na { color: var(--red); }')
+  expect(resultC.warnings()).toHaveLength(0)
+
+  expect(resultD.css).toEqual(':root { --pink: #ffc0cb; }\na { color: var(--pink); }')
+  expect(resultD.warnings()).toHaveLength(0)
+
+  expect(resultE.css).toEqual('a { color: green; }')
+  expect(resultE.warnings()).toHaveLength(0)
+})

--- a/index.test.js
+++ b/index.test.js
@@ -497,3 +497,31 @@ it('Supports parallel runners', async () => {
   expect(resultE.css).toEqual('a { color: green; }')
   expect(resultE.warnings()).toHaveLength(0)
 })
+
+it('Supports parallel runners when reading from a file', async () => {
+  const pluginInstance = plugin({ files: ['./props.test.css'] });
+
+  let [resultA, resultB, resultC, resultD] = await Promise.all([
+    postcss([pluginInstance]).process(`a { color: var(--red); }`, { from: undefined }),
+    postcss([pluginInstance]).process(`a { color: var(--pink); }`, { from: undefined }),
+    postcss([pluginInstance]).process(`a { color: var(--red); }`, { from: undefined }),
+    postcss([pluginInstance]).process(`a { color: var(--pink); }`, { from: undefined }),
+  ])
+
+  let resultE = await postcss([pluginInstance]).process(`a { color: green; }`, { from: undefined })
+
+  expect(resultA.css).toEqual(':root { --red: #f00; }\na { color: var(--red); }')
+  expect(resultA.warnings()).toHaveLength(0)
+
+  expect(resultB.css).toEqual(':root { --pink: #ffc0cb; }\na { color: var(--pink); }')
+  expect(resultB.warnings()).toHaveLength(0)
+
+  expect(resultC.css).toEqual(':root { --red: #f00; }\na { color: var(--red); }')
+  expect(resultC.warnings()).toHaveLength(0)
+
+  expect(resultD.css).toEqual(':root { --pink: #ffc0cb; }\na { color: var(--pink); }')
+  expect(resultD.warnings()).toHaveLength(0)
+
+  expect(resultE.css).toEqual('a { color: green; }')
+  expect(resultE.warnings()).toHaveLength(0)
+})


### PR DESCRIPTION
_This looks like a massive change because the indent changed by wrapping everything in `prepare`._

Changed :

- use `prepare` to make sure that each time a plugin instance runs it starts from the same state
- deep clone of the `UserProps` to make sure that there is no weird drift in state during file watching
- emit a message that will be picked up by tools like `postcss-cli`

see : https://github.com/GoogleChromeLabs/postcss-jit-props/issues/24#issuecomment-1378342599

I am unsure how widespread the support for `dependency` messages through PostCSS is.
Some tools might support it, others might not. [PostCSS CLI](https://www.npmjs.com/package/postcss-cli) definitely supports it and it is clearly documented in the guidelines for [PostCSS](https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#31-rebuild-when-dependencies-change)

But I personally do not think it is up to plugins to implement file watching through things like chokidar. Better to leave this up to builders, bundlers, meta frameworks, ...