### PR TITLE
feat: add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+import { PluginCreator } from "postcss";
+
+export interface Options {
+  /**
+   * Wraps the entire rule inside `@layer` syntax.
+   */
+  layer?: string;
+
+  /**
+   * Where search for css props, globbing allowed.
+   */
+  files?: string[];
+
+  /**
+   * Selector where the props are pushed to instead of `:root`.
+   */
+  custom_selector?: string;
+}
+
+type Props = Record<string, string | number>;
+
+export type PostcssJitPropsOptions = Options & Props;
+declare const postcssJitProps: PluginCreator<PostcssJitPropsOptions>;
+
+export default postcssJitProps;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface Options {
   layer?: string;
 
   /**
-   * Where search for css props, globbing allowed.
+   * Where to search for css props, globbing allowed.
    */
   files?: string[];
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "css-vars",
     "css-custom-properties"
   ],
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest --coverage && eslint .",
     "dev": "jest --coverage --watch",


### PR DESCRIPTION
This add types support and closes #53.

### Testing
- [x] Tested locally on both `.ts` and `.mjs` postcss configs
- [ ] Required testing on `.cjs` or `.js` based config files

Options such as `custom_selector_dark` and one other, aren't added due to lack of documentation on README.md