### PR TITLE
fix: applying plugin on an empty css file

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,11 +127,13 @@ module.exports = (options) => {
           STATE.mapped = new Set()
           STATE.mapped_dark = new Set()
 
-          STATE.target_rule = new Rule({ selector: target_selector, source: node.first.source })
-          STATE.target_rule_dark = new Rule({ selector: target_selector_dark, source: node.first.source })
-          STATE.target_media_dark = new AtRule({ name: 'media', params: '(prefers-color-scheme: dark)', source: node.first.source })
+          if (node.first) {
+            STATE.target_rule = new Rule({ selector: target_selector, source: node.first.source })
+            STATE.target_rule_dark = new Rule({ selector: target_selector_dark, source: node.first.source })
+            STATE.target_media_dark = new AtRule({ name: 'media', params: '(prefers-color-scheme: dark)', source: node.first.source })
+          }
 
-          if (layer) {
+          if (layer && node.first) {
             STATE.target_layer = new AtRule({ name: 'layer', params: layer, source: node.first.source })
             node.root().prepend(STATE.target_layer)
             STATE.target_ss = STATE.target_layer

--- a/index.test.js
+++ b/index.test.js
@@ -575,3 +575,18 @@ it('Supports parallel runners when reading from a file', async () => {
   expect(resultE.css).toEqual('a { color: green; }')
   expect(resultE.warnings()).toHaveLength(0)
 })
+
+// situation encountered when using postcs-jit-props for Open Props
+// together with having @nuxt/fonts module with no global font definition
+// it still creates an empty .nuxt/nuxt-fonts-global.css file
+// and postcs-jit-props started to fail trying to parse it
+// --
+// fixed by adding "node.first" null check into parsing method
+// (lines 130 and 136 in index.js)
+
+it('Parses an empty file and rule', async () => {
+  const pluginInstance = plugin({ files: ['./props.test.empty.css'] });
+  let result = await postcss([pluginInstance]).process('');
+  expect(result.css).toEqual("");
+  expect(result.warnings()).toHaveLength(0);
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postcss-jit-props",
-  "version": "1.0.13",
+  "version": "1.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postcss-jit-props",
-      "version": "1.0.13",
+      "version": "1.0.15",
       "license": "Apache-2.0",
       "dependencies": {
         "tiny-glob": "^0.2.9"


### PR DESCRIPTION
Yesterday, I am trying to add @nuxt/fonts module into [my project](https://github.com/AloisSeckar/nuxt-ignis) where I already integrated Open Props using `postcss-jit-props` plugin. It turned out the plugin cannot handle empty css file (`.nuxt/nuxt-fonts-global.css`) that is auto-generated by @nuxt/fonts module and is empty when you don't specify any global font-family (which is common use case - fonts can be injected into CSS locally only where you need them).

The error was:
```
ERROR  Internal server error: [postcss] Cannot read properties of undefined (reading 'source')                                                   22:25:52  
  Plugin: vite:css
  File: C:/Programming/Git/nuxt-ignis/.nuxt/nuxt-fonts-global.css:undefined:NaN
      at Object.Once (C:\Programming\Git\nuxt-ignis\node_modules\.pnpm\postcss-jit-props@1.0.15_postcss@8.4.49\node_modules\postcss-jit-props\index.js:130:88)
      at LazyResult.runOnRoot (C:\Programming\Git\nuxt-ignis\node_modules\.pnpm\postcss@8.5.1\node_modules\postcss\lib\lazy-result.js:327:23)
      at LazyResult.runAsync (C:\Programming\Git\nuxt-ignis\node_modules\.pnpm\postcss@8.5.1\node_modules\postcss\lib\lazy-result.js:258:26)
      at LazyResult.async (C:\Programming\Git\nuxt-ignis\node_modules\.pnpm\postcss@8.5.1\node_modules\postcss\lib\lazy-result.js:160:30)
      at LazyResult.then (C:\Programming\Git\nuxt-ignis\node_modules\.pnpm\postcss@8.5.1\node_modules\postcss\lib\lazy-result.js:404:17)
```

This lead me to this repo and to `index.js` file implementation.

When I added null checks for `node.first` my error disappeared (while Open Props are still being injected as expected).

To have a quick fix working for me, I made a fork and created custom NPM package `elrh-postcss-jit-props`, but I believe it would be better to have it here in the official repo.

I also added test as a POC (if you remove the null checks, it starts failing).

If I did something wrong, I am happy to hear a feedback.